### PR TITLE
Temperature module

### DIFF
--- a/Main/FESTIM.py
+++ b/Main/FESTIM.py
@@ -734,7 +734,8 @@ def compute_error(parameters, t, u_n, mesh):
     return tab
 
 
-def compute_retention(res, W):
+def compute_retention(u, W):
+    res = list(split(u))
     if not res:  # if u is non-vector
         res = [u]
     retention = project(res[0])
@@ -879,7 +880,7 @@ def run(parameters):
 
         # Post prossecing
         res = list(u.split())
-        retention = compute_retention(res, W)
+        retention = compute_retention(u, W)
         res.append(retention)
         export_xdmf(res,
                     exports, files, t)

--- a/Main/FESTIM.py
+++ b/Main/FESTIM.py
@@ -842,6 +842,7 @@ def run(parameters):
 
     timer = Timer()  # start timer
     error = []
+    temperature = [["t (s)", "T (K)"]]
     t = 0  # Initialising time to 0s
     while t < Time:
         # Update current time
@@ -883,7 +884,7 @@ def run(parameters):
         export_xdmf(res,
                     exports, files, t)
         dt = export_profiles(res, exports, t, dt, W)
-
+        temperature.append([t, T(size/2)])
         inventory = assemble(retention*dx)
         desorption_rate = [-(inventory-inventory_n)/float(dt), T(size/2), t]
         inventory_n = inventory
@@ -908,7 +909,7 @@ def run(parameters):
     output["error"] = error
     output["parameters"] = parameters
     output["mesh"] = mesh
-
+    output["temperature"] = temperature
     # End
     print('\007s')
     return output

--- a/Main/FESTIM.py
+++ b/Main/FESTIM.py
@@ -15,8 +15,8 @@ def tds_to_csv(parameters, desorption):
             file_tds = ''
             if "folder" in p.keys():
                 file_tds += p["folder"] + '/'
+                os.makedirs(os.path.dirname(file_tds), exist_ok=True)
             file_tds += p["file"] + ".csv"
-            os.makedirs(os.path.dirname(file_tds), exist_ok=True)
         busy = True
         while busy is True:
             try:
@@ -786,8 +786,8 @@ def run(parameters):
         FT, expressions_FT = \
             define_variational_problem_heat_transfers(
                 parameters, [T, vT, T_n], [dx, ds], dt)
-        if parameters["temperature"]["type"] == "solve_stationnary":
-            print("Solving stationnary heat equation")
+        if parameters["temperature"]["type"] == "solve_stationary":
+            print("Solving stationary heat equation")
             solve(FT == 0, T, bcs_T)
         elif parameters["temperature"]["type"] == "solve_transient":
             T_n = sp.printing.ccode(

--- a/Main/test.py
+++ b/Main/test.py
@@ -268,7 +268,7 @@ def test_formulation_2_traps_1_material():
     '''
     Test function formulation() with 2 intrinsic traps
     and 1 material
-    '''    
+    '''
     # Set parameters
     dt = 1
     traps = [{
@@ -468,7 +468,7 @@ def test_formulation_1_extrap_1_material():
             "D_0": 5,
             "id": 1
             }]
-    
+
     mesh = fenics.UnitIntervalMesh(10)
     V = fenics.VectorFunctionSpace(mesh, 'P', 1, 2)
     W = fenics.FunctionSpace(mesh, 'P', 1)
@@ -552,17 +552,6 @@ def test_run_temperature_stationary():
                     "value": u,
                     "surface": [1, 2]
                 }
-                #{
-                #    "type": "neumann",
-                #    "value": 10e6,
-                #    "surface": 2
-                #},
-                #{
-                #    "type": "convective_flux",
-                #    "h_coeff": 70000,
-                #    "T_ext": 273.15+75,
-                #    "surface": 1
-                #}
                 ],
             "source_term": [
                 {

--- a/Main/test.py
+++ b/Main/test.py
@@ -505,6 +505,111 @@ def test_formulation_1_extrap_1_material():
     assert expected_form.equals(F) is True
 
 
+def test_run_temperature():
+    '''
+    Check that the temperature module works well in 1D stationary
+    '''
+    u = 1 + 2*FESTIM.x**2
+    size = 1
+    parameters = {
+        "materials": [
+            {
+                "thermal_cond": 1,
+                "alpha": 1.1e-10,
+                "beta": 6*6.3e28,
+                "density": 6.3e28,
+                "borders": [0, size],
+                "E_diff": 0.39,
+                "D_0": 4.1e-7,
+                "id": 1
+                }
+                ],
+        "traps": [
+            ],
+        "mesh_parameters": {
+                "initial_number_of_cells": 200,
+                "size": size,
+                "refinements": [
+                ],
+            },
+        "boundary_conditions": [
+                    {
+                        "surface": [1],
+                        "value": 1,
+                        "component": 0,
+                        "type": "dc"
+                    }
+            ],
+        "temperature": {
+            "type": "solve_stationary",
+            "boundary_conditions": [
+                {
+                    "type": "dirichlet",
+                    "value": u,
+                    "surface": [1, 2]
+                }
+                #{
+                #    "type": "neumann",
+                #    "value": 10e6,
+                #    "surface": 2
+                #},
+                #{
+                #    "type": "convective_flux",
+                #    "h_coeff": 70000,
+                #    "T_ext": 273.15+75,
+                #    "surface": 1
+                #}
+                ],
+            "source_term": [
+                {
+                    "value": -4,
+                    "volume": 1
+                }
+            ],
+            "initial_condition": u
+        },
+        "source_term": {
+            'flux': 0
+            },
+        "solving_parameters": {
+            "final_time": 30,
+            "num_steps": 60,
+            "adaptative_time_step": {
+                "stepsize_change_ratio": 1,
+                "t_stop": 40,
+                "stepsize_stop_max": 0.5,
+                "dt_min": 1e-5
+                },
+            "newton_solver": {
+                "absolute_tolerance": 1e10,
+                "relative_tolerance": 1e-9,
+                "maximum_it": 50,
+            }
+            },
+        "exports": {
+            "txt": {
+                "functions": ['retention'],
+                "times": [100],
+                "labels": ['retention']
+            },
+            "xdmf": {
+                "functions": [],
+                "labels":  [],
+                "folder": "Coucou"
+            },
+            "TDS": {
+                "file": "desorption",
+                "TDS_time": 450
+                }
+            },
+
+    }
+    output = FESTIM.run(parameters)
+    # temp at the middle
+    T_computed = output["temperature"][1][1]
+    assert abs(T_computed - (1+2*(size/2)**2)) < 1e-9
+
+
 def test_run_MMS():
     '''
     Test function run() for several refinements

--- a/Main/test.py
+++ b/Main/test.py
@@ -4,6 +4,8 @@ import pytest
 import sympy as sp
 
 
+# Unit tests
+
 def test_mesh_and_refine_meets_refinement_conditions():
     '''
     Test that function mesh_and_refine() gives the right
@@ -504,6 +506,8 @@ def test_formulation_1_extrap_1_material():
 
     assert expected_form.equals(F) is True
 
+
+# Integration tests
 
 def test_run_temperature_stationary():
     '''

--- a/Main/test.py
+++ b/Main/test.py
@@ -856,4 +856,6 @@ def test_run_MMS():
             with h = ' + str(h) + '\n \
             with dt = ' + str(dt)
         print(msg)
+        assert output["temperature"][1][1] == 700
+        assert output["temperature"][5][1] == 700
         assert error_max_u < tol_u and error_max_v < tol_v


### PR DESCRIPTION
I added 2 options to the `"temperature"` key in `parameters`.
Users can now:
1. set the temperature by solving stationary heat equation
In `parameters`:
```python
    "temperature": {
        "type": "solve_transient",
        "boundary_conditions": [
            {
                "type": "dirichlet",
                "value": 1,
                "surface": [1]
            },
            {
                "type": "neumann",
                "value": 10e6,
                "surface": 2
            },
            {
                "type": "convective_flux",
                "h_coeff": 70000,
                "T_ext": 273.15+75,
                "surface": [3, 4]
            }
            ],
        "source_term": [
            {
                "value": 2,
                "volume": [1, 2]
            }
        ]
    }
```
2. set the temperature by solving transient heat equation
In `parameters`:
```python
    "temperature": {
        "type": "solve_transient",
        "boundary_conditions": [
            {
                "type": "dirichlet",
                "value": x ** 2,
                "surface": [1]
            },
            {
                "type": "neumann",
                "value": 10e6,
                "surface": 2
            },
            {
                "type": "convective_flux",
                "h_coeff": 70000,
                "T_ext": 273.15+75 + t,
                "surface": [3, 4]
            }
            ],
        "source_term": [
            {
                "value": x**2 + t,
                "volume": 1
            }
        ],
        "initial_condition": 0
    }
```