### PR TITLE
Trap densities as function of space and time

### DIFF
--- a/Main/FESTIM.py
+++ b/Main/FESTIM.py
@@ -328,14 +328,14 @@ def formulation(traps, extrinsic_traps, solutions, testfunctions,
     i = 1  # index in traps
     j = 0  # index in extrinsic_traps
     for trap in traps:
-        if 'type' in trap.keys():
-            if trap['type'] == 'extrinsic':
-                trap_density = extrinsic_traps[j]
-                j += 1
-            else:
-                trap_density = trap['density']
+        if 'type' in trap.keys() and trap['type'] == 'extrinsic':
+            trap_density = extrinsic_traps[j]
+            j += 1
         else:
-            trap_density = trap['density']
+            trap_density = sp.printing.ccode(trap['density'])
+            trap_density = Expression(trap_density, degree=2, t=0)
+            expressions.append(trap_density)
+
         energy = trap['energy']
         material = trap['materials']
         F += ((solutions[i] - previous_solutions[i]) / dt) * \
@@ -868,7 +868,7 @@ def run(parameters):
     temperature = [["t (s)", "T (K)"]]
     t = 0  # Initialising time to 0s
     while t < Time:
-        ## Update current time
+        # Update current time
         t += float(dt)
         expressions = update_expressions(expressions, t)
         expressions_form = update_expressions(expressions_form, t)

--- a/Main/test.py
+++ b/Main/test.py
@@ -285,7 +285,7 @@ def test_formulation_2_traps_1_material():
     materials = [{
             "alpha": 1,
             "beta": 2,
-            "density": 3 + FESTIM.t,
+            "density": 3,
             "borders": [0, 1],
             "E_diff": 4,
             "D_0": 5,


### PR DESCRIPTION
Users can now define intrinsic traps' densities as function of space (non homogeneous trap distribution) and time (to mimick extrinsic traps without solving ODEs).

It goes like this in the parameters dict:
```python
import FESTIM
traps = [{
    "energy": 1,
    "density": 2 + FESTIM.x**2 + FESTIM.t,
    "materials": [1, 2]
     }]
```

Unit tests for `FESTIM.formulation` have been modified in order to take into account the new type for density (from `float` to `fenics.Expression()`)