### PR TITLE
Post processing

### DIFF
--- a/Main/FESTIM.py
+++ b/Main/FESTIM.py
@@ -43,6 +43,8 @@ def write_to_csv(dict, desorption):
                       "Please close the application then press any key")
                 input()
 
+    return True
+
 
 def export_txt(filename, function, W):
     '''
@@ -797,7 +799,7 @@ def calculate_minimum_volume(f, subdomains, subd_id):
 
 def header_derived_quantities(parameters):
     '''
-    Creates the header for post_proc list
+    Creates the header for derived_quantities list
     '''
     header = ['t(s)']
     i = 0
@@ -1070,9 +1072,9 @@ def run(parameters):
     output["mesh"] = mesh
     output["temperature"] = temperature
     if "derived_quantities" in parameters["exports"].keys():
-        output["derived_quantities"] = post_proc_global
+        output["derived_quantities"] = derived_quantities_global
         write_to_csv(parameters["exports"]["derived_quantities"],
-                     post_proc_global)
+                     derived_quantities_global)
     # Export TDS
     if "TDS" in parameters["exports"].keys():
         output["TDS"] = desorption

--- a/Main/FESTIM.py
+++ b/Main/FESTIM.py
@@ -828,22 +828,21 @@ def header_post_processing(parameters):
                     "exports"]["derived_quantities"]["average_volume"]:
         for vol in average["volumes"]:
             header.append(
-                "Average " + average['field'] + " on surface " + str(vol))
+                "Average " + average['field'] + " volume " + str(vol))
     for minimum in parameters[
                     "exports"]["derived_quantities"]["minimum_volume"]:
         for vol in minimum["volumes"]:
-            header.append("Minimum " + minimum["field"] + " vol " + str(vol))
+            header.append("Minimum " + minimum["field"] + " volume " + str(vol))
     for maximum in parameters[
                     "exports"]["derived_quantities"]["maximum_volume"]:
         for vol in maximum["volumes"]:
-            header.append("Maximum " + minimum["field"] + " vol " + str(vol))
+            header.append("Maximum " + maximum["field"] + " volume " + str(vol))
     for total in parameters["exports"]["derived_quantities"]["total_volume"]:
         for vol in total["volumes"]:
-            header.append("Total " + minimum["field"] + " vol " + str(vol))
+            header.append("Total " + total["field"] + " volume " + str(vol))
     for total in parameters["exports"]["derived_quantities"]["total_surface"]:
-        sol = field_to_sol[total["field"]]
         for surf in total["surfaces"]:
-            header.append("Total " + minimum["field"] + " surf " + str(surf))
+            header.append("Total " + total["field"] + " surface " + str(surf))
 
     return header
 

--- a/Main/FESTIM.py
+++ b/Main/FESTIM.py
@@ -76,7 +76,7 @@ def export_profiles(res, exports, t, dt, W):
     Exports 1D profiles in txt files.
     Arguments:
     - res: list, contains FEniCS Functions
-    - exports: dict, defined by define_exports()
+    - exports: dict, dict, contains parameters
     - t: float, time
     - dt: FEniCS Constant(), stepsize
     Returns:
@@ -129,7 +129,7 @@ def define_xdmf_files(exports):
     '''
     Returns a list of XDMFFile
     Arguments:
-    - exports: dict, defined by define_exports()
+    - exports: dict, contains parameters
     '''
     if len(exports['xdmf']['functions']) != len(exports['xdmf']['labels']):
         raise NameError("Number of functions to be exported "
@@ -153,7 +153,7 @@ def export_xdmf(res, exports, files, t):
     Exports the solutions fields in xdmf files.
     Arguments:
     - res: list, contains FEniCS Functions
-    - exports: dict, defined by define_exports()
+    - exports: dict, contains parameters
     - files: list, contains XDMFFile
     - t: float
     '''
@@ -1003,8 +1003,6 @@ def run(parameters):
     #  Time-stepping
     print('Time stepping...')
 
-    export_total = list()
-
     timer = Timer()  # start timer
     error = []
     if "derived_quantities" in parameters["exports"].keys():
@@ -1078,16 +1076,15 @@ def run(parameters):
         for j in range(len(previous_solutions_traps)):
             previous_solutions_traps[j].assign(extrinsic_traps[j])
 
-    # Compute error
-    try:
-        error = compute_error(parameters["exports"]["error"], t, u_n, mesh)
-    except:
-        pass
+
 
     # Store data in output
     output = dict()  # Final output
 
-    output["error"] = error
+    # Compute error
+    if "error" in parameters["exports"].keys():
+        error = compute_error(parameters["exports"]["error"], t, u_n, mesh)
+        output["error"] = error
     output["parameters"] = parameters
     output["mesh"] = mesh
     output["temperature"] = temperature

--- a/Main/FESTIM.py
+++ b/Main/FESTIM.py
@@ -832,7 +832,7 @@ def header_post_processing(parameters):
     for minimum in parameters[
                     "exports"]["derived_quantities"]["minimum_volume"]:
         for vol in minimum["volumes"]:
-            header.append("Minimum " + minimum["field"] + "vol " + str(vol))
+            header.append("Minimum " + minimum["field"] + " vol " + str(vol))
     for maximum in parameters[
                     "exports"]["derived_quantities"]["maximum_volume"]:
         for vol in maximum["volumes"]:

--- a/Main/FESTIM.py
+++ b/Main/FESTIM.py
@@ -828,7 +828,7 @@ def header_post_processing(parameters):
                     "exports"]["derived_quantities"]["average_volume"]:
         for vol in average["volumes"]:
             header.append(
-                "Average " + average['field'] + "on surface " + str(vol))
+                "Average " + average['field'] + " on surface " + str(vol))
     for minimum in parameters[
                     "exports"]["derived_quantities"]["minimum_volume"]:
         for vol in minimum["volumes"]:
@@ -836,14 +836,14 @@ def header_post_processing(parameters):
     for maximum in parameters[
                     "exports"]["derived_quantities"]["maximum_volume"]:
         for vol in maximum["volumes"]:
-            header.append("Maximum " + minimum["field"] + "vol " + str(vol))
+            header.append("Maximum " + minimum["field"] + " vol " + str(vol))
     for total in parameters["exports"]["derived_quantities"]["total_volume"]:
         for vol in total["volumes"]:
-            header.append("Total " + minimum["field"] + "vol " + str(vol))
+            header.append("Total " + minimum["field"] + " vol " + str(vol))
     for total in parameters["exports"]["derived_quantities"]["total_surface"]:
         sol = field_to_sol[total["field"]]
         for surf in total["surfaces"]:
-            header.append("Total " + minimum["field"] + "surf " + str(surf))
+            header.append("Total " + minimum["field"] + " surf " + str(surf))
 
     return header
 

--- a/Main/FESTIM.py
+++ b/Main/FESTIM.py
@@ -769,50 +769,28 @@ def compute_retention(u, W):
     return retention
 
 
-def calculate_maximum_volume(u, cell_function, subdomain_id):
-    '''
-    Computes the maxmimum value of Function u on the domain subdomain_id
-    based on MeshFunction cell_function
-    '''
-    V = u.function_space()
-    dofmap = V.dofmap()
-    mesh = V.mesh()
-    maxi = u.vector().min()
-    for cell in cells(mesh):
-        if cell_function[cell.index()] == subdomain_id:
-            dofs = dofmap.cell_dofs(cell.index())
-            for dof in dofs:
-                try:
-                    [dof][0]
-                    if u.vector()[dof][0] > maxi:
-                        maxi = u.vector()[dof][0]
-                except:
-                    if u.vector()[dof] > maxi:
-                        maxi = u.vector()[dof]
-    return maxi
+def calculate_maximum_volume(f, subdomains, subd_id):
+    '''Minimum of f over subdomains cells marked with subd_id'''
+    V = f.function_space()
+
+    dm = V.dofmap()
+
+    subd_dofs = np.unique(np.hstack(
+        [dm.cell_dofs(c.index()) for c in SubsetIterator(subdomains, subd_id)]))
+
+    return np.max(f.vector().get_local()[subd_dofs])
 
 
-def calculate_minimum_volume(u, cell_function, subdomain_id):
-    '''
-    Computes the minimum value of Function u on the domain subdomain_id
-    based on MeshFunction cell_function
-    '''
-    V = u.function_space()
-    dofmap = V.dofmap()
-    mesh = V.mesh()
-    mini = u.vector().max()
-    for cell in cells(mesh):
-        if cell_function[cell.index()] == subdomain_id:
-            dofs = dofmap.cell_dofs(cell.index())
-            for dof in dofs:
-                try:
-                    [dof][0]
-                    if u.vector()[dof][0] < mini:
-                        mini = u.vector()[dof][0]
-                except:
-                    if u.vector()[dof] < mini:
-                        mini = u.vector()[dof]
-    return mini
+def calculate_minimum_volume(f, subdomains, subd_id):
+    '''Minimum of f over subdomains cells marked with subd_id'''
+    V = f.function_space()
+
+    dm = V.dofmap()
+
+    subd_dofs = np.unique(np.hstack(
+        [dm.cell_dofs(c.index()) for c in SubsetIterator(subdomains, subd_id)]))
+
+    return np.min(f.vector().get_local()[subd_dofs])
 
 
 def header_post_processing(parameters):

--- a/Main/FESTIM.py
+++ b/Main/FESTIM.py
@@ -832,11 +832,13 @@ def header_post_processing(parameters):
     for minimum in parameters[
                     "exports"]["derived_quantities"]["minimum_volume"]:
         for vol in minimum["volumes"]:
-            header.append("Minimum " + minimum["field"] + " volume " + str(vol))
+            header.append(
+                "Minimum " + minimum["field"] + " volume " + str(vol))
     for maximum in parameters[
                     "exports"]["derived_quantities"]["maximum_volume"]:
         for vol in maximum["volumes"]:
-            header.append("Maximum " + maximum["field"] + " volume " + str(vol))
+            header.append(
+                "Maximum " + maximum["field"] + " volume " + str(vol))
     for total in parameters["exports"]["derived_quantities"]["total_volume"]:
         for vol in total["volumes"]:
             header.append("Total " + total["field"] + " volume " + str(vol))

--- a/Main/FESTIM.py
+++ b/Main/FESTIM.py
@@ -776,7 +776,8 @@ def calculate_maximum_volume(f, subdomains, subd_id):
     dm = V.dofmap()
 
     subd_dofs = np.unique(np.hstack(
-        [dm.cell_dofs(c.index()) for c in SubsetIterator(subdomains, subd_id)]))
+        [dm.cell_dofs(c.index())
+         for c in SubsetIterator(subdomains, subd_id)]))
 
     return np.max(f.vector().get_local()[subd_dofs])
 
@@ -788,12 +789,13 @@ def calculate_minimum_volume(f, subdomains, subd_id):
     dm = V.dofmap()
 
     subd_dofs = np.unique(np.hstack(
-        [dm.cell_dofs(c.index()) for c in SubsetIterator(subdomains, subd_id)]))
+        [dm.cell_dofs(c.index())
+         for c in SubsetIterator(subdomains, subd_id)]))
 
     return np.min(f.vector().get_local()[subd_dofs])
 
 
-def header_post_processing(parameters):
+def header_derived_quantities(parameters):
     '''
     Creates the header for post_proc list
     '''
@@ -827,7 +829,7 @@ def header_post_processing(parameters):
     return header
 
 
-def post_processing(parameters, solutions, properties, markers):
+def derived_quantities(parameters, solutions, properties, markers):
     '''
     Computes all the derived_quantities and store it into list
     '''
@@ -987,7 +989,7 @@ def run(parameters):
     timer = Timer()  # start timer
     error = []
     if "derived_quantities" in parameters["exports"].keys():
-        post_proc_global = [header_post_processing(parameters)]
+        derived_quantities_global = [header_derived_quantities(parameters)]
     if "TDS" in parameters["exports"].keys():
         inventory_n = 0
         desorption = [["t (s)", "T (K)", "d (m-2.s-1)"]]
@@ -1032,13 +1034,13 @@ def run(parameters):
         retention = compute_retention(u, W)
         res.append(retention)
         if "derived_quantities" in parameters["exports"].keys():
-            post_proc_t = post_processing(
+            derived_quantities_t = derived_quantities(
                 parameters,
                 [u, retention, T],
                 [1, 1],
                 [volume_markers, surface_markers])
-            post_proc_t.insert(0, t)
-            post_proc_global.append(post_proc_t)
+            derived_quantities_t.insert(0, t)
+            derived_quantities_global.append(derived_quantities_t)
         if "xdmf" in parameters["exports"].keys():
             export_xdmf(res,
                         exports, files, t)

--- a/Main/FESTIM.py
+++ b/Main/FESTIM.py
@@ -862,6 +862,8 @@ def post_processing(parameters, solutions, properties, markers):
     n = FacetNormal(mesh)
     dx = Measure('dx', domain=mesh, subdomain_data=volume_markers)
     ds = Measure('ds', domain=mesh, subdomain_data=surface_markers)
+
+    # Create dicts
     field_to_sol = {
         'solute': solutions[0],
         'retention': solutions[len(solutions)-2],
@@ -879,7 +881,7 @@ def post_processing(parameters, solutions, properties, markers):
             val = interpolate(val, V)
             field_to_sol[key] = val
     tab = []
-
+    # Compute quantities
     for flux in parameters["exports"]["derived_quantities"]["surface_flux"]:
         sol = field_to_sol[flux["field"]]
         prop = field_to_prop[flux["field"]]
@@ -1075,8 +1077,6 @@ def run(parameters):
         u_n.assign(u)
         for j in range(len(previous_solutions_traps)):
             previous_solutions_traps[j].assign(extrinsic_traps[j])
-
-
 
     # Store data in output
     output = dict()  # Final output

--- a/Main/test.py
+++ b/Main/test.py
@@ -591,6 +591,71 @@ def test_post_processing():
     assert len(tab) == len(expected)
     for i in range(0, len(tab)):
         assert abs(tab[i] - expected[i])/expected[i] < 1e-3
+
+
+def test_header_post_processing():
+    # Set parameters for derived quantities
+    parameters = {
+        "exports": {
+            "derived_quantities": {
+                "surface_flux": [
+                    {
+                        "field": 'solute',
+                        "surfaces": [2]
+                    },
+                    {
+                        "field": 'T',
+                        "surfaces": [2]
+                    },
+                ],
+                "average_volume": [
+                    {
+                        "field": 'T',
+                        "volumes": [1]
+                    }
+                ],
+                "total_volume": [
+                    {
+                        "field": 'solute',
+                        "volumes": [1, 2]
+                    }
+                ],
+                "total_surface": [
+                    {
+                        "field": 'solute',
+                        "surfaces": [2]
+                    }
+                ],
+                "maximum_volume": [
+                    {
+                        "field": 'T',
+                        "volumes": [1]
+                    }
+                ],
+                "minimum_volume": [
+                    {
+                        "field": 'solute',
+                        "volumes": [2]
+                    }
+                ],
+                "file": "derived_quantities",
+                "folder": "",
+            }
+        }
+    }
+
+    tab = FESTIM.header_post_processing(parameters)
+    expected = ["t(s)",
+                "Flux surface 2: solute", "Flux surface 2: T",
+                "Average T volume 1",
+                "Minimum solute volume 2", "Maximum T volume 1",
+                "Total solute volume 1", "Total solute volume 2",
+                "Total solute surface 2"]
+    assert len(tab) == len(expected)
+    for i in range(0, len(tab)):
+        assert tab[i] == expected[i]
+
+
 # Integration tests
 
 

--- a/Main/test.py
+++ b/Main/test.py
@@ -514,9 +514,9 @@ def test_formulation_1_extrap_1_material():
     assert expected_form.equals(F) is True
 
 
-def test_post_processing():
+def test_derived_quantities():
     '''
-    Test the function FESTIM.post_processing()
+    Test the function FESTIM.derived_quantities()
     '''
     # Create Functions
     mesh = fenics.UnitIntervalMesh(10000)
@@ -585,15 +585,15 @@ def test_post_processing():
     # Expected result
     expected = [4, 4, 11/8, 9/8, 17/8, 9/32, 37/96, 2]
     # Compute
-    tab = FESTIM.post_processing(parameters, [u, u, T], [1, 1],
-                                 [volume_markers, surface_markers])
+    tab = FESTIM.derived_quantities(parameters, [u, u, T], [1, 1],
+                                    [volume_markers, surface_markers])
     # Compare
     assert len(tab) == len(expected)
     for i in range(0, len(tab)):
         assert abs(tab[i] - expected[i])/expected[i] < 1e-3
 
 
-def test_header_post_processing():
+def test_header_derived_quantities():
     # Set parameters for derived quantities
     parameters = {
         "exports": {
@@ -644,7 +644,7 @@ def test_header_post_processing():
         }
     }
 
-    tab = FESTIM.header_post_processing(parameters)
+    tab = FESTIM.header_derived_quantities(parameters)
     expected = ["t(s)",
                 "Flux surface 2: solute", "Flux surface 2: T",
                 "Average T volume 1",

--- a/Main/test.py
+++ b/Main/test.py
@@ -514,6 +514,41 @@ def test_formulation_1_extrap_1_material():
     assert expected_form.equals(F) is True
 
 
+def test_create_flux_functions():
+    '''
+    Test the function FESTIM.create_flux_functions()
+    '''
+    mesh = fenics.UnitIntervalMesh(10)
+    V = fenics.FunctionSpace(mesh, 'P', 1)
+    materials = [
+        {
+            "D_0": 2,
+            "E_diff": 3,
+            "thermal_cond": 4,
+            "id": 1
+            },
+        {
+            "D_0": 3,
+            "E_diff": 4,
+            "thermal_cond": 5,
+            "id": 2
+            }
+            ]
+    mf = fenics.MeshFunction("size_t", mesh, 1, 0)
+    for cell in fenics.cells(mesh):
+        x = cell.midpoint().x()
+        if x < 0.5:
+            mf[cell] = 1
+        else:
+            mf[cell] = 2
+    A, B, C = FESTIM.create_flux_functions(mesh, materials, mf)
+    for cell in fenics.cells(mesh):
+        cell_no = cell.index()
+        assert A.vector()[cell_no] == mf[cell]+1
+        assert B.vector()[cell_no] == mf[cell]+2
+        assert C.vector()[cell_no] == mf[cell]+3
+
+
 def test_derived_quantities():
     '''
     Test the function FESTIM.derived_quantities()


### PR DESCRIPTION
Users can now compute derived quatities such as surface fluxes or volume/surface integrations for temperature and solute concentrations. In parameters dict, do:
```python
"exports": {
    "derived_quantities": {
        "surface_flux": [
            {
                "field": 'solute',
                "surfaces": [1, 2]
            },
            {
                "field": 'T',
                "surfaces": [1, 2]
            },
        ],
        "average_volume": [
            {
                "field": 'T',
                "volumes": [1]
            }
        ],
        "total_surface": [
            {
                "field": 'solute',
                "volumes": [1]
            }
        ],
        "total_volume": [
            {
                "field": 'solute',
                "volumes": [1]
            }
        ],
        "maximum_volume": [
            {
                "field": 'T',
                "volumes": [1]
            }
        ],
        "minimum_volume": [
            {
                "field": 'T',
                "volumes": [1]
            }
        ],
        "file": "derived_quantities",
        "folder": "Folder",
    }
    }
```

This will then create a .csv file (Folder/derived_quantities.csv) containing the computed quantities for each time step.