### PR TITLE
Export parameters

### DIFF
--- a/FESTIM/export.py
+++ b/FESTIM/export.py
@@ -2,6 +2,8 @@ from fenics import *
 import csv
 import sys
 import os
+import sympy as sp
+import json
 import numpy as np
 
 
@@ -168,3 +170,33 @@ def export_xdmf(res, exports, files, t):
         solution.rename(label, "label")
         files[i].write(solution, t)
     return
+
+
+def treat_value(d):
+    '''
+    Recursively converts as string the sympy objects in d
+    Arguments: d, dict
+    '''
+    if type(d) is dict:
+        for key, value in d.items():
+            if isinstance(value, tuple(sp.core.all_classes)):
+                print(key, value)
+                value = str(sp.printing.ccode(value))
+                d[key] = value
+            elif type(value) is dict or type(value) is list:
+                d[key] = treat_value(value)
+    elif type(d) is list:
+        for e in d:
+            e = treat_value(e)
+    return d
+
+
+def export_parameters(parameters):
+    '''
+    Dumps parameters dict in a json file.
+    '''
+    json_file = parameters["exports"]["parameters"]
+    param = treat_value(parameters)
+    with open(json_file, 'w') as fp:
+        json.dump(param, fp, indent=4, sort_keys=True)
+    return True

--- a/FESTIM/export.py
+++ b/FESTIM/export.py
@@ -196,6 +196,9 @@ def export_parameters(parameters):
     Dumps parameters dict in a json file.
     '''
     json_file = parameters["exports"]["parameters"]
+    os.makedirs(os.path.dirname(json_file), exist_ok=True)
+    if json_file.endswith(".json") is False:
+        json_file += ".json"
     param = treat_value(parameters)
     with open(json_file, 'w') as fp:
         json.dump(param, fp, indent=4, sort_keys=True)

--- a/FESTIM/generic_simulation.py
+++ b/FESTIM/generic_simulation.py
@@ -4,6 +4,12 @@ import sympy as sp
 
 
 def run(parameters):
+    # Export parameters
+    try:  # if parameters are in the export key
+        FESTIM.export.export_parameters(parameters)
+    except:
+        pass
+
     # Declaration of variables
     Time = parameters["solving_parameters"]["final_time"]
     initial_stepsize = parameters["solving_parameters"]["initial_stepsize"]


### PR DESCRIPTION
Running a generic simulation.
The main parameters dict can now be exported to a JSON file using `FESTIM.export.export_parameters`.
The file name has to been set in the main parameters dict:
```python
exports = {
    "parameters": "name_file.json"
}
parameters["exports"] = exports
FESTIM.export.export_parameters(parameters)
FESTIM.generic_simulation.run(parameters)
```