### PR TITLE
Temperature dependent properties

### DIFF
--- a/FESTIM/export.py
+++ b/FESTIM/export.py
@@ -177,12 +177,15 @@ def treat_value(d):
     Recursively converts as string the sympy objects in d
     Arguments: d, dict
     '''
+    T = sp.symbols('T')
     if type(d) is dict:
         for key, value in d.items():
             if isinstance(value, tuple(sp.core.all_classes)):
                 print(key, value)
                 value = str(sp.printing.ccode(value))
                 d[key] = value
+            elif callable(value):  # if value is fun
+                d[key] = str(sp.printing.ccode(value(T)))
             elif type(value) is dict or type(value) is list:
                 d[key] = treat_value(value)
     elif type(d) is list:

--- a/FESTIM/formulations.py
+++ b/FESTIM/formulations.py
@@ -162,12 +162,15 @@ def define_variational_problem_heat_transfers(
         # Diffusion term
         F += thermal_cond*dot(grad(T), grad(vT))*dx(vol)
 
+    # Source terms
     for source in parameters["temperature"]["source_term"]:
         src = sp.printing.ccode(source["value"])
         src = Expression(src, degree=2, t=0)
         expressions.append(src)
         # Source term
         F += - src*vT*dx(source["volume"])
+
+    # Boundary conditions
     for bc in parameters["temperature"]["boundary_conditions"]:
         if type(bc["surface"]) is list:
             surfaces = bc["surface"]

--- a/FESTIM/formulations.py
+++ b/FESTIM/formulations.py
@@ -142,6 +142,8 @@ def define_variational_problem_heat_transfers(
         if "thermal_cond" not in mat.keys():
             raise NameError("Missing thermal_cond key in material")
         thermal_cond = mat["thermal_cond"]
+        if callable(thermal_cond):  # if thermal_cond is a function
+            thermal_cond = thermal_cond(T)
         vol = mat["id"]
         if parameters["temperature"]["type"] == "solve_transient":
             T_n = functions[2]
@@ -151,6 +153,10 @@ def define_variational_problem_heat_transfers(
                 raise NameError("Missing rho key in material")
             cp = mat["heat_capacity"]
             rho = mat["rho"]
+            if callable(cp):  # if cp or rho are functions, apply T
+                cp = cp(T)
+            if callable(rho):
+                rho = rho(T)
             # Transien term
             F += rho*cp*(T-T_n)/dt*vT*dx(vol)
         # Diffusion term


### PR DESCRIPTION
Users can now define thermal properties as functions as follow:
```python
from FESTIM.formulations import define_variational_problem_heat_transfers
from fenics import *


def cond(T):
    return T**2 + 3*T**3


def rho(T):
    return 1+T


def cp(T):
    return 3

parameters = {
    "materials": [
        {
            "thermal_cond": cond,
            "rho": rho,
            "heat_capacity": cp,
            "id": 1
            }
            ],
    "temperature": {
        "type": "solve_transient",
        "boundary_conditions": [
            ],
        "source_term": [
            {
                "value": 0,
                "volume": 1
            }
        ]
        }
        }
mesh = UnitSquareMesh(8, 8)
V = FunctionSpace(mesh, 'P', 1)
T = Function(V)
T_n = Function(V)
v = TestFunction(V)

F, exp = define_variational_problem_heat_transfers(
    parameters, [T, T_n, v], [dx, ds], 1)
print(F)

```
