### PR TITLE
Xdmf initial state

### DIFF
--- a/FESTIM/export.py
+++ b/FESTIM/export.py
@@ -138,7 +138,7 @@ def define_xdmf_files(exports):
     return files
 
 
-def export_xdmf(res, exports, files, t):
+def export_xdmf(res, exports, files, t, append):
     '''
     Exports the solutions fields in xdmf files.
     Arguments:
@@ -146,6 +146,7 @@ def export_xdmf(res, exports, files, t):
     - exports: dict, contains parameters
     - files: list, contains XDMFFile
     - t: float
+    - append: bool, erase the previous file or not
     '''
     if len(exports['xdmf']['functions']) > len(res):
         raise NameError("Too many functions to export "
@@ -168,7 +169,8 @@ def export_xdmf(res, exports, files, t):
                     " is unknown.")
 
         solution.rename(label, "label")
-        files[i].write(solution, t)
+        files[i].write_checkpoint(
+            solution, label, t, XDMFFile.Encoding.HDF5, append=append)
     return
 
 
@@ -181,7 +183,6 @@ def treat_value(d):
     if type(d) is dict:
         for key, value in d.items():
             if isinstance(value, tuple(sp.core.all_classes)):
-                print(key, value)
                 value = str(sp.printing.ccode(value))
                 d[key] = value
             elif callable(value):  # if value is fun

--- a/FESTIM/generic_simulation.py
+++ b/FESTIM/generic_simulation.py
@@ -116,7 +116,7 @@ def run(parameters):
     exports = parameters["exports"]
     if "xdmf" in parameters["exports"].keys():
         files = FESTIM.export.define_xdmf_files(exports)
-
+        append = False
     #  Time-stepping
     print('Time stepping...')
 
@@ -185,7 +185,8 @@ def run(parameters):
             derived_quantities_t.insert(0, t)
             derived_quantities_global.append(derived_quantities_t)
         if "xdmf" in parameters["exports"].keys():
-            FESTIM.export.export_xdmf(res, exports, files, t)
+            FESTIM.export.export_xdmf(res, exports, files, t, append=append)
+            append = True
         dt = FESTIM.export.export_profiles(res, exports, t, dt, W)
         temperature.append([t, T(size/2)])
 

--- a/FESTIM/generic_simulation.py
+++ b/FESTIM/generic_simulation.py
@@ -32,8 +32,9 @@ def run(parameters):
     # Create functions for flux computation
     if "derived_quantities" in parameters["exports"]:
         if "surface_flux" in parameters["exports"]["derived_quantities"]:
-            D_0, E_diff, thermal_cond = create_flux_functions(
-                mesh, parameters["materials"], volume_markers)
+            D_0, E_diff, thermal_cond =\
+                FESTIM.post_processing.create_flux_functions(
+                    mesh, parameters["materials"], volume_markers)
     # Define expressions used in variational forms
     print('Defining source terms')
     flux_ = Expression(
@@ -62,7 +63,9 @@ def run(parameters):
                 parameters, [T, vT, T_n], [dx, ds], dt)
         if parameters["temperature"]["type"] == "solve_stationary":
             print("Solving stationary heat equation")
+            T_file = XDMFFile("Sol_monoblock_1D_comparison/temperature.xdmf")
             solve(FT == 0, T, bcs_T)
+            T_file.write(T)
 
     # Define functions
 
@@ -74,9 +77,9 @@ def run(parameters):
         FESTIM.functionspaces_and_functions.define_test_functions(
             V, W, len(extrinsic_traps))
     # Initialising the solutions
-    try:
+    if "initial_conditions" in parameters.keys():
         initial_conditions = parameters["initial_conditions"]
-    except:
+    else:
         initial_conditions = []
     u_n, previous_solutions_concentrations = \
         FESTIM.initialise_solutions.initialising_solutions(
@@ -120,7 +123,8 @@ def run(parameters):
     timer = Timer()  # start timer
     error = []
     if "derived_quantities" in parameters["exports"].keys():
-        derived_quantities_global = [header_derived_quantities(parameters)]
+        derived_quantities_global = \
+            [FESTIM.post_processing.header_derived_quantities(parameters)]
     if "TDS" in parameters["exports"].keys():
         inventory_n = 0
         desorption = [["t (s)", "T (K)", "d (m-2.s-1)"]]

--- a/FESTIM/generic_simulation.py
+++ b/FESTIM/generic_simulation.py
@@ -14,7 +14,7 @@ def run(parameters):
     Time = parameters["solving_parameters"]["final_time"]
     initial_stepsize = parameters["solving_parameters"]["initial_stepsize"]
     dt = Constant(initial_stepsize)  # time step size
-    level = 30  # 30 for WARNING 20 for INFO
+    level = 40  # 30 for WARNING 20 for INFO
     set_log_level(level)
 
     # Mesh and refinement

--- a/FESTIM/initialise_solutions.py
+++ b/FESTIM/initialise_solutions.py
@@ -13,6 +13,9 @@ def initialising_solutions(V, initial_conditions):
     '''
     print('Defining initial values')
     u_n, components = FESTIM.functionspaces_and_functions.define_functions(V)
+
+    check_no_duplicates(initial_conditions)
+
     for ini in initial_conditions:
         if 'component' not in ini.keys():
             ini["component"] = 0
@@ -55,3 +58,17 @@ def initialising_extrinsic_traps(W, number_of_traps):
         ini = Expression("0", degree=2)
         previous_solutions.append(interpolate(ini, W))
     return previous_solutions
+
+
+def check_no_duplicates(initial_conditions):
+    components = []
+    for e in initial_conditions:
+        if "component" not in e:
+            comp = 0
+        else:
+            comp = e["component"]
+        if comp in components:
+            raise ValueError("Duplicate component " + str(comp))
+        else:
+            components.append(comp)
+    return

--- a/FESTIM/initialise_solutions.py
+++ b/FESTIM/initialise_solutions.py
@@ -16,9 +16,20 @@ def initialising_solutions(V, initial_conditions):
     # initial conditions are 0 by default
     expression = ['0'] * len(components)
     for ini in initial_conditions:
-        value = ini["value"]
-        value = sp.printing.ccode(value)
-        comp = Expression(value, degree=3, t=0)
+        if type(ini['value']) == str and ini['value'].endswith(".xdmf"):
+            comp = Function(V.sub(ini["component"]).collapse())
+            if "label" not in ini.keys():
+                raise KeyError("label key not found")
+            if "time_step" not in ini.keys():
+                raise KeyError("time_step key not found")
+            with XDMFFile(ini["value"]) as file:
+                file.read_checkpoint(comp, ini["label"], ini["time_step"])
+            #  only works if meshes are the same
+        else:
+            print('coucou')
+            value = ini["value"]
+            value = sp.printing.ccode(value)
+            comp = Expression(value, degree=3, t=0)
         comp = interpolate(comp, V.sub(ini["component"]).collapse())
         assign(u_n.sub(ini["component"]), comp)
     components = split(u_n)

--- a/FESTIM/initialise_solutions.py
+++ b/FESTIM/initialise_solutions.py
@@ -13,10 +13,11 @@ def initialising_solutions(V, initial_conditions):
     '''
     print('Defining initial values')
     u_n, components = FESTIM.functionspaces_and_functions.define_functions(V)
-    # initial conditions are 0 by default
-    expression = ['0'] * len(components)
     for ini in initial_conditions:
+        if 'component' not in ini.keys():
+            ini["component"] = 0
         if type(ini['value']) == str and ini['value'].endswith(".xdmf"):
+
             if V.num_sub_spaces() > 0:
                 comp = Function(V.sub(ini["component"]).collapse())
             else:

--- a/FESTIM/initialise_solutions.py
+++ b/FESTIM/initialise_solutions.py
@@ -17,7 +17,10 @@ def initialising_solutions(V, initial_conditions):
     expression = ['0'] * len(components)
     for ini in initial_conditions:
         if type(ini['value']) == str and ini['value'].endswith(".xdmf"):
-            comp = Function(V.sub(ini["component"]).collapse())
+            if V.num_sub_spaces() > 0:
+                comp = Function(V.sub(ini["component"]).collapse())
+            else:
+                comp = Function(V)
             if "label" not in ini.keys():
                 raise KeyError("label key not found")
             if "time_step" not in ini.keys():
@@ -29,11 +32,12 @@ def initialising_solutions(V, initial_conditions):
             value = ini["value"]
             value = sp.printing.ccode(value)
             comp = Expression(value, degree=3, t=0)
-        if V.dim() > 1:
+        if V.num_sub_spaces() > 0:
             comp = interpolate(comp, V.sub(ini["component"]).collapse())
+            assign(u_n.sub(ini["component"]), comp)
         else:
-            comp = interpolate(comp, V)
-        assign(u_n.sub(ini["component"]), comp)
+            u_n = interpolate(comp, V)
+
     components = split(u_n)
     return u_n, components
 

--- a/FESTIM/initialise_solutions.py
+++ b/FESTIM/initialise_solutions.py
@@ -18,13 +18,9 @@ def initialising_solutions(V, initial_conditions):
     for ini in initial_conditions:
         value = ini["value"]
         value = sp.printing.ccode(value)
-        expression[ini["component"]] = value
-    if len(expression) == 1:
-        expression = expression[0]
-    else:
-        expression = tuple(expression)
-    ini_u = Expression(expression, degree=3, t=0)
-    u_n = interpolate(ini_u, V)
+        comp = Expression(value, degree=3, t=0)
+        comp = interpolate(comp, V.sub(ini["component"]).collapse())
+        assign(u_n.sub(ini["component"]), comp)
     components = split(u_n)
     return u_n, components
 

--- a/FESTIM/initialise_solutions.py
+++ b/FESTIM/initialise_solutions.py
@@ -26,11 +26,13 @@ def initialising_solutions(V, initial_conditions):
                 file.read_checkpoint(comp, ini["label"], ini["time_step"])
             #  only works if meshes are the same
         else:
-            print('coucou')
             value = ini["value"]
             value = sp.printing.ccode(value)
             comp = Expression(value, degree=3, t=0)
-        comp = interpolate(comp, V.sub(ini["component"]).collapse())
+        if V.dim() > 1:
+            comp = interpolate(comp, V.sub(ini["component"]).collapse())
+        else:
+            comp = interpolate(comp, V)
         assign(u_n.sub(ini["component"]), comp)
     components = split(u_n)
     return u_n, components

--- a/Tests/test_initialisation.py
+++ b/Tests/test_initialisation.py
@@ -1,0 +1,152 @@
+import FESTIM
+from FESTIM import initialise_solutions
+import pytest
+import fenics
+import os
+from pathlib import Path
+
+
+def test_initialisation_from_xdmf(tmpdir):
+    mesh = fenics.UnitSquareMesh(5, 5)
+    V = fenics.VectorFunctionSpace(mesh, 'P', 1, 2)
+    u = fenics.Function(V)
+    w = fenics.Function(V)
+    ini_u = fenics.Expression("1", degree=1)
+    ini_u = fenics.interpolate(ini_u, V.sub(0).collapse())
+    fenics.assign(u.sub(0), ini_u)
+    ini_u = fenics.Expression("1", degree=1)
+    ini_u = fenics.interpolate(ini_u, V.sub(1).collapse())
+    fenics.assign(u.sub(1), ini_u)
+
+    d = tmpdir.mkdir("Initial solutions")
+    file1 = d.join("u_1out.xdmf")
+    file2 = d.join("u_2out.xdmf")
+    print(Path(file1))
+    with fenics.XDMFFile(str(Path(file1))) as file:
+        file.write_checkpoint(u.sub(0), "1", 2, fenics.XDMFFile.Encoding.HDF5,
+                              append=False)
+    with fenics.XDMFFile(str(Path(file2))) as file:
+        file.write_checkpoint(u.sub(1), "2", 2, fenics.XDMFFile.Encoding.HDF5,
+                              append=False)
+        file.write_checkpoint(u.sub(1), "2", 4, fenics.XDMFFile.Encoding.HDF5,
+                              append=True)
+
+    parameters = {
+        "initial_conditions": [
+            {
+                "value": str(Path(file1)),
+                "component": 0,
+                "label": "1",
+                "time_step": 0
+            },
+            {
+                "value": str(Path(file2)),
+                "component": 1,
+                "label": "2",
+                "time_step": 1
+            },
+        ],
+    }
+    w, components = initialise_solutions.initialising_solutions(
+        V, parameters["initial_conditions"])
+    assert fenics.errornorm(u, w) == 0
+
+
+def test_fail_initialisation_from_xdmf():
+    '''
+    Test that the function fails initialising_solutions if
+    there's a missing key
+    '''
+    mesh = fenics.UnitSquareMesh(5, 5)
+    V = fenics.VectorFunctionSpace(mesh, 'P', 1, 2)
+
+    parameters = {
+        "initial_conditions": [
+            {
+                "value": "Initial solutions/u_1out.xdmf",
+                "component": 0,
+                "label": "1",
+            },
+            {
+                "value": "Initial solutions/u_2out.xdmf",
+                "component": 1,
+                "label": "2",
+                "time_step": 1
+            },
+        ],
+    }
+    with pytest.raises(KeyError, match=r'time_step'):
+        initialise_solutions.initialising_solutions(
+            V, parameters["initial_conditions"])
+
+    parameters = {
+        "initial_conditions": [
+            {
+                "value": "Initial solutions/u_1out.xdmf",
+                "component": 0,
+                "time_step": 1
+            },
+            {
+                "value": "Initial solutions/u_2out.xdmf",
+                "component": 1,
+                "time_step": 1
+            },
+        ],
+    }
+    with pytest.raises(KeyError, match=r'label'):
+        initialise_solutions.initialising_solutions(
+            V, parameters["initial_conditions"])
+
+
+def test_initialisation_with_expression():
+    '''
+    Test that initialising_solutions interpolates correctly
+    from an expression
+    '''
+    mesh = fenics.UnitSquareMesh(8, 8)
+    V = fenics.VectorFunctionSpace(mesh, 'P', 1, 2)
+    u = fenics.Function(V)
+    w = fenics.Function(V)
+    ini_u = fenics.Expression("1+x[0] + x[1]", degree=1)
+    ini_u = fenics.interpolate(ini_u, V.sub(0).collapse())
+    fenics.assign(u.sub(0), ini_u)
+    ini_u = fenics.Expression("1+x[0]", degree=1)
+    ini_u = fenics.interpolate(ini_u, V.sub(1).collapse())
+    fenics.assign(u.sub(1), ini_u)
+
+    parameters = {
+        "initial_conditions": [
+            {
+                "value": 1+FESTIM.x + FESTIM.y,
+                "component": 0,
+            },
+            {
+                "value": 1+FESTIM.x,
+                "component": 1,
+            },
+        ],
+    }
+    w, components = initialise_solutions.initialising_solutions(
+        V, parameters["initial_conditions"])
+    assert fenics.errornorm(u, w) == 0
+
+
+def test_initialisation_default():
+    '''
+    Test that initialising_solutions interpolates correctly
+    if nothing is given (default is 0)
+    '''
+    mesh = fenics.UnitSquareMesh(8, 8)
+    V = fenics.VectorFunctionSpace(mesh, 'P', 1, 2)
+    u = fenics.Function(V)
+    w = fenics.Function(V)
+    ini_u = fenics.Expression("0", degree=1)
+    ini_u = fenics.interpolate(ini_u, V.sub(0).collapse())
+    fenics.assign(u.sub(0), ini_u)
+    ini_u = fenics.Expression("0", degree=1)
+    ini_u = fenics.interpolate(ini_u, V.sub(1).collapse())
+    fenics.assign(u.sub(1), ini_u)
+
+    w, components = initialise_solutions.initialising_solutions(
+        V, [])
+    assert fenics.errornorm(u, w) == 0

--- a/Tests/test_initialisation.py
+++ b/Tests/test_initialisation.py
@@ -193,3 +193,28 @@ def test_initialisation_no_component():
     w, components = initialise_solutions.initialising_solutions(
         V, parameters["initial_conditions"])
     assert fenics.errornorm(u, w) == 0
+
+
+def test_initialisation_duplicates():
+    '''
+    Test that initialising_solutions set component at 0
+    by default
+    '''
+    mesh = fenics.UnitSquareMesh(8, 8)
+    V = fenics.VectorFunctionSpace(mesh, 'P', 1, 3)
+
+    parameters = {
+        "initial_conditions": [
+            {
+                "value": 1+FESTIM.x + FESTIM.y,
+                "component": 0
+            },
+            {
+                "value": 1+FESTIM.x + FESTIM.y,
+                "component": 0
+            },
+        ],
+    }
+    with pytest.raises(KeyError, match=r'duplicate'):
+        initialise_solutions.initialising_solutions(
+            V, parameters["initial_conditions"])

--- a/Tests/test_initialisation.py
+++ b/Tests/test_initialisation.py
@@ -152,19 +152,26 @@ def test_initialisation_default():
     assert fenics.errornorm(u, w) == 0
 
 
-def test_initialisation_default_solute_only():
+def test_initialisation_solute_only():
     '''
     Test that initialising_solutions interpolates correctly
-    if nothing is given (default is 0) and solution has
-    only 1 component (ie solute)
+    if solution has only 1 component (ie solute)
     '''
     mesh = fenics.UnitSquareMesh(8, 8)
     V = fenics.FunctionSpace(mesh, 'P', 1)
     u = fenics.Function(V)
     w = fenics.Function(V)
-    ini_u = fenics.Expression("0", degree=1)
+    ini_u = fenics.Expression("1 + x[0] + x[1]", degree=1)
     u = fenics.interpolate(ini_u, V)
 
+    parameters = {
+        "initial_conditions": [
+            {
+                "value": 1+FESTIM.x + FESTIM.y,
+                "component": 0,
+            },
+        ],
+    }
     w, components = initialise_solutions.initialising_solutions(
-        V, [])
+        V, parameters["initial_conditions"])
     assert fenics.errornorm(u, w) == 0

--- a/Tests/test_initialisation.py
+++ b/Tests/test_initialisation.py
@@ -150,3 +150,21 @@ def test_initialisation_default():
     w, components = initialise_solutions.initialising_solutions(
         V, [])
     assert fenics.errornorm(u, w) == 0
+
+
+def test_initialisation_default_solute_only():
+    '''
+    Test that initialising_solutions interpolates correctly
+    if nothing is given (default is 0) and solution has
+    only 1 component (ie solute)
+    '''
+    mesh = fenics.UnitSquareMesh(8, 8)
+    V = fenics.FunctionSpace(mesh, 'P', 1)
+    u = fenics.Function(V)
+    w = fenics.Function(V)
+    ini_u = fenics.Expression("0", degree=1)
+    u = fenics.interpolate(ini_u, V)
+
+    w, components = initialise_solutions.initialising_solutions(
+        V, [])
+    assert fenics.errornorm(u, w) == 0

--- a/Tests/test_initialisation.py
+++ b/Tests/test_initialisation.py
@@ -215,6 +215,6 @@ def test_initialisation_duplicates():
             },
         ],
     }
-    with pytest.raises(KeyError, match=r'duplicate'):
+    with pytest.raises(ValueError, match=r'Duplicate'):
         initialise_solutions.initialising_solutions(
             V, parameters["initial_conditions"])

--- a/Tests/test_initialisation.py
+++ b/Tests/test_initialisation.py
@@ -163,12 +163,11 @@ def test_initialisation_solute_only():
     w = fenics.Function(V)
     ini_u = fenics.Expression("1 + x[0] + x[1]", degree=1)
     u = fenics.interpolate(ini_u, V)
-
     parameters = {
         "initial_conditions": [
             {
                 "value": 1+FESTIM.x + FESTIM.y,
-                "component": 0,
+                "component": 0
             },
         ],
     }

--- a/Tests/test_initialisation.py
+++ b/Tests/test_initialisation.py
@@ -140,12 +140,6 @@ def test_initialisation_default():
     V = fenics.VectorFunctionSpace(mesh, 'P', 1, 2)
     u = fenics.Function(V)
     w = fenics.Function(V)
-    ini_u = fenics.Expression("0", degree=1)
-    ini_u = fenics.interpolate(ini_u, V.sub(0).collapse())
-    fenics.assign(u.sub(0), ini_u)
-    ini_u = fenics.Expression("0", degree=1)
-    ini_u = fenics.interpolate(ini_u, V.sub(1).collapse())
-    fenics.assign(u.sub(1), ini_u)
 
     w, components = initialise_solutions.initialising_solutions(
         V, [])
@@ -168,6 +162,31 @@ def test_initialisation_solute_only():
             {
                 "value": 1+FESTIM.x + FESTIM.y,
                 "component": 0
+            },
+        ],
+    }
+    w, components = initialise_solutions.initialising_solutions(
+        V, parameters["initial_conditions"])
+    assert fenics.errornorm(u, w) == 0
+
+
+def test_initialisation_no_component():
+    '''
+    Test that initialising_solutions set component at 0
+    by default
+    '''
+    mesh = fenics.UnitSquareMesh(8, 8)
+    V = fenics.VectorFunctionSpace(mesh, 'P', 1, 3)
+    u = fenics.Function(V)
+    w = fenics.Function(V)
+    ini_u = fenics.Expression("1 + x[0] + x[1]", degree=1)
+    ini_u = fenics.interpolate(ini_u, V.sub(0).collapse())
+    fenics.assign(u.sub(0), ini_u)
+
+    parameters = {
+        "initial_conditions": [
+            {
+                "value": 1+FESTIM.x + FESTIM.y,
             },
         ],
     }

--- a/Tests/test_integration_initialisation_export.py
+++ b/Tests/test_integration_initialisation_export.py
@@ -1,0 +1,93 @@
+import FESTIM
+from FESTIM import export
+from FESTIM import initialise_solutions
+import fenics
+import pytest
+import sympy as sp
+from pathlib import Path
+
+
+def test_export_and_initialise_xdmf(tmpdir):
+    '''
+    Test if an exported file can be read as initial condition
+    '''
+    # Write
+    mesh = fenics.UnitSquareMesh(3, 3)
+    V = fenics.FunctionSpace(mesh, 'P', 1)
+    ini_u = fenics.Expression("0", degree=1)
+    u = fenics.interpolate(ini_u, V)
+
+    exports = {
+        "xdmf": {
+            "functions": ['solute'],
+            "labels":  ['1'],
+            "folder": "Solution"
+        }
+        }
+
+    d = tmpdir.mkdir("Initial solutions")
+    file1 = d.join("u_1out.xdmf")
+    files = [fenics.XDMFFile(str(Path(file1)))]
+    export.export_xdmf(
+        [u],
+        exports, files, 20)
+
+    #  Read
+    parameters = {
+        "initial_conditions": [
+            {
+                "value": str(Path(file1)),
+                "component": 0,
+                "label": "1",
+                "time_step": 0
+            },
+        ],
+    }
+    assert initialise_solutions.initialising_solutions(
+        V, parameters["initial_conditions"])
+
+
+def test_initialise_and_export_xdmf(tmpdir):
+    '''
+    Test if an initialised solution can be exported
+    '''
+    mesh = fenics.UnitSquareMesh(5, 5)
+    V = fenics.FunctionSpace(mesh, 'P', 1)
+    u = fenics.Function(V)
+    ini_u = fenics.Expression("1", degree=1)
+    u = fenics.interpolate(ini_u, V)
+
+    d = tmpdir.mkdir("Initial solutions")
+    file1 = d.join("u_1in.xdmf")
+    with fenics.XDMFFile(str(Path(file1))) as file:
+        file.write_checkpoint(u, "1", 2, fenics.XDMFFile.Encoding.HDF5,
+                              append=False)
+    # Read
+    parameters = {
+        "initial_conditions": [
+            {
+                "value": str(Path(file1)),
+                "component": 0,
+                "label": "1",
+                "time_step": 0
+            },
+        ],
+    }
+    v, components = initialise_solutions.initialising_solutions(
+        V, parameters["initial_conditions"])
+
+    # Write
+    exports = {
+        "xdmf": {
+            "functions": ['solute'],
+            "labels":  ['1'],
+            "folder": "Solution"
+        }
+        }
+
+    d2 = tmpdir.mkdir("Output")
+    file2 = d.join("u_1out.xdmf")
+    files = [fenics.XDMFFile(str(Path(file2)))]
+    assert export.export_xdmf(
+        [v],
+        exports, files, 20) is None

--- a/Tests/test_integration_initialisation_export.py
+++ b/Tests/test_integration_initialisation_export.py
@@ -30,7 +30,7 @@ def test_export_and_initialise_xdmf(tmpdir):
     files = [fenics.XDMFFile(str(Path(file1)))]
     export.export_xdmf(
         [u],
-        exports, files, 20)
+        exports, files, 20, append=False)
 
     #  Read
     parameters = {
@@ -90,4 +90,4 @@ def test_initialise_and_export_xdmf(tmpdir):
     files = [fenics.XDMFFile(str(Path(file2)))]
     assert export.export_xdmf(
         [v],
-        exports, files, 20) is None
+        exports, files, 20, append=False) is None

--- a/Tests/test_postprocessing.py
+++ b/Tests/test_postprocessing.py
@@ -57,20 +57,20 @@ def test_export_xdmf():
              fenics.XDMFFile(folder + "/" + "b.xdmf")]
     assert FESTIM.export.export_xdmf(
         [fenics.Function(V), fenics.Function(V)],
-        exports, files, 20) is None
+        exports, files, 20, append=True) is None
 
     exports["xdmf"]["functions"] = ['solute', 'blabla']
 
     with pytest.raises(KeyError, match=r'blabla'):
         FESTIM.export.export_xdmf(
             [fenics.Function(V), fenics.Function(V)],
-            exports, files, 20)
+            exports, files, 20, append=True)
 
     exports["xdmf"]["functions"] = ['solute', '13']
     with pytest.raises(KeyError, match=r'13'):
         FESTIM.export.export_xdmf(
             [fenics.Function(V), fenics.Function(V)],
-            exports, files, 20)
+            exports, files, 20, append=True)
 
 
 def test_create_flux_functions():

--- a/Tests/test_system.py
+++ b/Tests/test_system.py
@@ -1,0 +1,352 @@
+import FESTIM
+import fenics
+import pytest
+import sympy as sp
+
+
+# Integration tests
+
+def test_run_temperature_stationary():
+    '''
+    Check that the temperature module works well in 1D stationary
+    '''
+    u = 1 + 2*FESTIM.x**2
+    size = 1
+    parameters = {
+        "materials": [
+            {
+                "thermal_cond": 1,
+                "alpha": 1.1e-10,
+                "beta": 6*6.3e28,
+                "density": 6.3e28,
+                "borders": [0, size],
+                "E_diff": 0.39,
+                "D_0": 4.1e-7,
+                "id": 1
+                }
+                ],
+        "traps": [
+            ],
+        "mesh_parameters": {
+                "initial_number_of_cells": 200,
+                "size": size,
+                "refinements": [
+                ],
+            },
+        "boundary_conditions": [
+                    {
+                        "surface": [1],
+                        "value": 1,
+                        "component": 0,
+                        "type": "dc"
+                    }
+            ],
+        "temperature": {
+            "type": "solve_stationary",
+            "boundary_conditions": [
+                {
+                    "type": "dirichlet",
+                    "value": u,
+                    "surface": [1, 2]
+                }
+                ],
+            "source_term": [
+                {
+                    "value": -4,
+                    "volume": 1
+                }
+            ],
+            "initial_condition": u
+        },
+        "source_term": {
+            'value': 0
+            },
+        "solving_parameters": {
+            "final_time": 30,
+            "initial_stepsize": 0.5,
+            "adaptive_stepsize": {
+                "stepsize_change_ratio": 1,
+                "t_stop": 40,
+                "stepsize_stop_max": 0.5,
+                "dt_min": 1e-5
+                },
+            "newton_solver": {
+                "absolute_tolerance": 1e10,
+                "relative_tolerance": 1e-9,
+                "maximum_iterations": 50,
+            }
+            },
+        "exports": {
+            "txt": {
+                "functions": ['retention'],
+                "times": [100],
+                "labels": ['retention']
+            },
+            "xdmf": {
+                "functions": [],
+                "labels":  [],
+                "folder": "Coucou"
+            },
+            "TDS": {
+                "file": "desorption",
+                "TDS_time": 450
+                }
+            },
+
+    }
+    output = FESTIM.generic_simulation.run(parameters)
+    # temp at the middle
+    T_computed = output["temperature"][1][1]
+    assert abs(T_computed - (1+2*(size/2)**2)) < 1e-9
+
+
+def test_run_temperature_transient():
+    '''
+    Check that the temperature module works well in 1D transient
+    '''
+    u = 1 + 2*FESTIM.x**2+FESTIM.t
+    size = 1
+    parameters = {
+        "materials": [
+            {
+                "thermal_cond": 1,
+                "rho": 1,
+                "heat_capacity": 1,
+                "alpha": 1.1e-10,  # lattice constant ()
+                "beta": 6*6.3e28,  # number of solute sites per atom (6 for W)
+                "density": 6.3e28,
+                "borders": [0, size],
+                "E_diff": 0.39,
+                "D_0": 4.1e-7,
+                "id": 1
+            }
+            ],
+        "traps": [
+            ],
+        "mesh_parameters": {
+                "initial_number_of_cells": 200,
+                "size": size,
+                "refinements": [
+                ],
+            },
+        "boundary_conditions": [
+                    {
+                        "surface": [1],
+                        "value": 1,
+                        "component": 0,
+                        "type": "dc"
+                    }
+            ],
+        "temperature": {
+            "type": "solve_transient",
+            "boundary_conditions": [
+                {
+                    "type": "dirichlet",
+                    "value": u,
+                    "surface": [1, 2]
+                }
+                ],
+            "source_term": [
+                {
+                    "value": sp.diff(u, FESTIM.t) - sp.diff(u, FESTIM.x, 2),
+                    "volume": 1
+                }
+            ],
+            "initial_condition": u
+        },
+        "source_term": {
+            'value': 0
+            },
+        "solving_parameters": {
+            "final_time": 30,
+            "initial_stepsize": 0.5,
+            "adaptive_stepsize": {
+                "stepsize_change_ratio": 1,
+                "t_stop": 40,
+                "stepsize_stop_max": 0.5,
+                "dt_min": 1e-5
+                },
+            "newton_solver": {
+                "absolute_tolerance": 1e10,
+                "relative_tolerance": 1e-9,
+                "maximum_iterations": 50,
+            }
+            },
+        "exports": {
+            "txt": {
+                "functions": ['retention'],
+                "times": [100],
+                "labels": ['retention']
+            },
+            "xdmf": {
+                "functions": [],
+                "labels":  [],
+                "folder": "Coucou"
+            },
+            "TDS": {
+                "file": "desorption",
+                "TDS_time": 450
+                }
+            },
+
+    }
+    output = FESTIM.generic_simulation.run(parameters)
+    # temp at the middle
+    T_computed = output["temperature"][1][1]
+    error = []
+    u_D = fenics.Expression(sp.printing.ccode(u), t=0, degree=4)
+    for i in range(1, len(output["temperature"])):
+        t = output["temperature"][i][0]
+        T = output["temperature"][i][1]
+        u_D.t = t
+        error.append(abs(T - u_D(size/2)))
+    assert max(error) < 1e-9
+
+
+def test_run_MMS():
+    '''
+    Test function run() for several refinements
+    '''
+
+    u = 1 + sp.exp(-4*fenics.pi**2*FESTIM.t)*sp.cos(2*fenics.pi*FESTIM.x)
+    v = 1 + sp.exp(-4*fenics.pi**2*FESTIM.t)*sp.cos(2*fenics.pi*FESTIM.x)
+
+    def parameters(h, dt, final_time, u, v):
+        size = 1
+        folder = 'Solution_Test'
+        v_0 = 1e13
+        E_t = 1.5
+        T = 700
+        density = 1 * 6.3e28
+        beta = 6*density
+        alpha = 1.1e-10
+        n_trap = 1e-1*density
+        E_diff = 0.39
+        D_0 = 4.1e-7
+        k_B = 8.6e-5
+        D = D_0 * fenics.exp(-E_diff/k_B/T)
+        v_i = v_0 * fenics.exp(-E_t/k_B/T)
+        v_m = D/alpha/alpha/beta
+
+        f = sp.diff(u, FESTIM.t) + sp.diff(v, FESTIM.t) - \
+            D * sp.diff(u, FESTIM.x, 2)
+        g = sp.diff(v, FESTIM.t) + v_i*v - v_m * u * (n_trap-v)
+        parameters = {
+            "materials": [
+                {
+                    "alpha": alpha,  # lattice constant ()
+                    "beta": beta,  # number of solute sites per atom (6 for W)
+                    "density": density,
+                    "borders": [0, size],
+                    "E_diff": E_diff,
+                    "D_0": D_0,
+                    "id": 1
+                    }
+                    ],
+            "traps": [
+                {
+                    "energy": E_t,
+                    "density": n_trap,
+                    "materials": 1,
+                    "source_term": g
+                }
+                ],
+            "initial_conditions": [
+                {
+                    "value": u,
+                    "component": 0
+                },
+                {
+                    "value": v,
+                    "component": 1
+                }
+            ],
+
+            "mesh_parameters": {
+                    "initial_number_of_cells": round(size/h),
+                    "size": size,
+                    "refinements": [
+                    ],
+                },
+            "boundary_conditions": [
+                    {
+                        "surface": [1, 2],
+                        "value": u,
+                        "component": 0,
+                        "type": "dc"
+                    },
+                    {
+                        "surface": [1, 2],
+                        "value": v,
+                        "component": 1,
+                        "type": "dc"
+                    }
+                ],
+            "temperature": {
+                    'type': "expression",
+                    'value': T
+                },
+            "source_term": {
+                'value': f
+                },
+            "solving_parameters": {
+                "final_time": final_time,
+                "initial_stepsize": dt,
+                "adaptive_stepsize": {
+                    "stepsize_change_ratio": 1,
+                    "t_stop": 0,
+                    "stepsize_stop_max": dt,
+                    "dt_min": 1e-5
+                    },
+                "newton_solver": {
+                    "absolute_tolerance": 1e-10,
+                    "relative_tolerance": 1e-9,
+                    "maximum_iterations": 50,
+                }
+                },
+            "exports": {
+                "txt": {
+                    "functions": [],
+                    "times": [],
+                    "labels": [],
+                    "folder": folder
+                },
+                "xdmf": {
+                    "functions": [],
+                    "labels":  [],
+                    "folder": folder
+                },
+                "TDS": {
+                    "file": "desorption",
+                    "TDS_time": 0,
+                    "folder": folder
+                    },
+                "error": [
+                    {
+                        "exact_solution": [u, v],
+                        "norm": 'error_max',
+                        "degree": 4
+                    }
+                ]
+                },
+        }
+        return parameters
+
+    tol_u = 1e-7
+    tol_v = 1e-1
+    sizes = [1/1600, 1/1700]
+    dt = 0.1/50
+    final_time = 0.1
+    for h in sizes:
+        output = FESTIM.generic_simulation.run(
+            parameters(h, dt, final_time, u, v))
+        error_max_u = output["error"][0][1]
+        error_max_v = output["error"][0][2]
+        msg = 'Maximum error on u is:' + str(error_max_u) + '\n \
+            Maximum error on v is:' + str(error_max_v) + '\n \
+            with h = ' + str(h) + '\n \
+            with dt = ' + str(dt)
+        print(msg)
+        assert output["temperature"][1][1] == 700
+        assert output["temperature"][5][1] == 700
+        assert error_max_u < tol_u and error_max_v < tol_v


### PR DESCRIPTION
Users can now use xdmf as an initial state.
Simply set the initial conditions in `parameters` as a xdmf path:

```python
import FESTIM
from FESTIM import initialise_solutions
from fenics import *

# write files
mesh = UnitSquareMesh(8, 8)
V = VectorFunctionSpace(mesh, 'P', 1, 2)
u = Function(V)
ini_u = Expression("0", degree=0)

ini_u = interpolate(ini_u, V.sub(0).collapse())
assign(u.sub(0), ini_u)
ini_u = interpolate(ini_u, V.sub(1).collapse())
assign(u.sub(1), ini_u)


with XDMFFile("solute.xdmf") as file:
    file.write_checkpoint(u.sub(0), "solute", 2, XDMFFile.Encoding.HDF5, append=False)
    file.write_checkpoint(u.sub(0), "solute", 3, XDMFFile.Encoding.HDF5, append=True)
    file.write_checkpoint(u.sub(0), "solute", 4, XDMFFile.Encoding.HDF5, append=True)
with XDMFFile("1.xdmf") as file:
    file.write_checkpoint(u.sub(1), "1", 0, XDMFFile.Encoding.HDF5, append=False)

# Read files
"initial_conditions": [
    {
        "value": "solute.xdmf",
        "component": 0,  # 0 stands for the first component of solution (solute)
        "label": "solute",  # label in the file
        "time_step": 2  # ie third time step in the file
    },
    {
        "value": "1.xdmf",
        "component": 1,  # 1 stands for the second component
        "label": "1",
        "time_step": 0  # ie first time step in the file
    },
]
initialise_solutions.initialising_solutions(V, parameters["initial_conditions"])
```


