### PR TITLE
Meshes and subdomains definition

### DIFF
--- a/FESTIM/generic_simulation.py
+++ b/FESTIM/generic_simulation.py
@@ -18,14 +18,14 @@ def run(parameters, log_level=40):
 
     # Mesh and refinement
     size = parameters["mesh_parameters"]["size"]
-    mesh = FESTIM.meshing.mesh_and_refine(parameters["mesh_parameters"])
+    mesh = FESTIM.meshing.create_mesh(parameters["mesh_parameters"])
     # Define function space for system of concentrations and properties
     V, W = FESTIM.functionspaces_and_functions.create_function_spaces(
         mesh, len(parameters["traps"]))
 
     # Define and mark subdomains
     volume_markers, surface_markers = \
-        FESTIM.meshing.subdomains(mesh, parameters["materials"], size)
+        FESTIM.meshing.subdomains(mesh, parameters)
     ds = Measure('ds', domain=mesh, subdomain_data=surface_markers)
     dx = Measure('dx', domain=mesh, subdomain_data=volume_markers)
     # Create functions for flux computation

--- a/FESTIM/meshing.py
+++ b/FESTIM/meshing.py
@@ -3,10 +3,15 @@ from operator import itemgetter
 
 
 def create_mesh(mesh_parameters):
+    print(type(Mesh()))
     if "cells_file" in mesh_parameters.keys():
         # Read volumetric mesh
         mesh = Mesh()
         XDMFFile(mesh_parameters["cells_file"]).read(mesh)
+    elif ("mesh" in mesh_parameters.keys() and
+            isinstance(mesh_parameters["mesh"], type(Mesh()))):
+            print('coucou')
+            mesh = mesh_parameters["mesh"]
     else:
         mesh = mesh_and_refine(mesh_parameters)
     return mesh
@@ -20,6 +25,12 @@ def subdomains(mesh, parameters):
                 mesh,
                 mesh_parameters["cells_file"],
                 mesh_parameters["facets_file"])
+    elif ("meshfunction_cells" in mesh_parameters.keys() and
+            isinstance(
+                mesh_parameters["meshfunction_cells"],
+                type(MeshFunction("size_t", mesh, mesh.topology().dim())))):
+        volume_markers = mesh_parameters["meshfunction_cells"]
+        surface_markers = mesh_parameters["meshfunction_facets"]
     else:
         size = parameters["mesh_parameters"]["size"]
         check_borders(size, parameters["materials"])

--- a/FESTIM/meshing.py
+++ b/FESTIM/meshing.py
@@ -3,14 +3,12 @@ from operator import itemgetter
 
 
 def create_mesh(mesh_parameters):
-    print(type(Mesh()))
     if "cells_file" in mesh_parameters.keys():
         # Read volumetric mesh
         mesh = Mesh()
         XDMFFile(mesh_parameters["cells_file"]).read(mesh)
     elif ("mesh" in mesh_parameters.keys() and
             isinstance(mesh_parameters["mesh"], type(Mesh()))):
-            print('coucou')
             mesh = mesh_parameters["mesh"]
     else:
         mesh = mesh_and_refine(mesh_parameters)

--- a/FESTIM/meshing.py
+++ b/FESTIM/meshing.py
@@ -3,10 +3,10 @@ from operator import itemgetter
 
 
 def create_mesh(mesh_parameters):
-    if "cells_file" in mesh_parameters.keys():
+    if "mesh_file" in mesh_parameters.keys():
         # Read volumetric mesh
         mesh = Mesh()
-        XDMFFile(mesh_parameters["cells_file"]).read(mesh)
+        XDMFFile(mesh_parameters["mesh_file"]).read(mesh)
     elif ("mesh" in mesh_parameters.keys() and
             isinstance(mesh_parameters["mesh"], type(Mesh()))):
             mesh = mesh_parameters["mesh"]

--- a/FESTIM/meshing.py
+++ b/FESTIM/meshing.py
@@ -5,7 +5,7 @@ def create_mesh(mesh_parameters):
     if "cells_file" in mesh_parameters.keys():
         # Read volumetric mesh
         mesh = Mesh()
-        XDMFFile(volumetric_file).read(mesh)
+        XDMFFile(mesh_parameters["cells_file"]).read(mesh)
     else:
         mesh = mesh_and_refine(mesh_parameters)
     return mesh

--- a/FESTIM/meshing.py
+++ b/FESTIM/meshing.py
@@ -1,4 +1,5 @@
 from fenics import *
+from operator import itemgetter
 
 
 def create_mesh(mesh_parameters):
@@ -19,6 +20,7 @@ def subdomains(mesh, parameters):
                 mesh_parameters["cells_file"], mesh_parameters["facets_file"])
     else:
         size = parameters["mesh_parameters"]["size"]
+        check_borders(size, parameters["materials"])
         volume_markers, surface_markers = \
             subdomains_1D(mesh, parameters["materials"], size)
     return volume_markers, surface_markers
@@ -110,3 +112,19 @@ def subdomains_1D(mesh, materials, size):
         if near(x0.x(), size):
             surface_markers[f] = 2
     return volume_markers, surface_markers
+
+
+def check_borders(size, materials):
+    check = True
+    all_borders = []
+    for m in materials:
+        all_borders.append(m["borders"])
+    all_borders = sorted(all_borders, key=itemgetter(0))
+    if all_borders[0][0] is not 0:
+        raise ValueError("Borders don't begin at zero")
+    for i in range(0, len(all_borders)-1):
+        if all_borders[i][1] != all_borders[i+1][0]:
+            raise ValueError("Borders don't match to each other")
+    if all_borders[len(all_borders) - 1][1] != size:
+        raise ValueError("Borders don't match with size")
+    return True

--- a/Tests/test_meshing.py
+++ b/Tests/test_meshing.py
@@ -3,6 +3,7 @@ from FESTIM import meshing
 import fenics
 import pytest
 import sympy as sp
+from pathlib import Path
 
 
 def test_mesh_and_refine_meets_refinement_conditions():
@@ -130,17 +131,17 @@ def test_check_borders():
         meshing.check_borders(size, materials)
 
 
-def test_create_mesh_xdmf():
+def test_create_mesh_xdmf(tmpdir):
 
     # write xdmf file
     mesh = fenics.UnitSquareMesh(10, 10)
-    f = fenics.XDMFFile("mesh.xdmf")
+    file1 = tmpdir.join("mesh.xdmf")
+    f = fenics.XDMFFile(str(Path(file1)))
     f.write(mesh)
 
     # read mesh
     mesh_parameters = {
-        "cells_file": "mesh.xdmf",
-        "facets_file": "Maillages Monoblock/Mesh 8/mesh_8_line.xdmf"
+        "cells_file": str(Path(file1)),
         }
     mesh2 = meshing.create_mesh(mesh_parameters)
 
@@ -160,19 +161,19 @@ def test_create_mesh_xdmf():
         assert vertices_mesh[i] == vertices_mesh2[i]
 
 
-def test_subdomains_from_xdmf():
+def test_subdomains_from_xdmf(tmpdir):
 
     # write files
     mesh = fenics.UnitCubeMesh(6, 6, 6)
     mf_cells = fenics.MeshFunction("size_t", mesh, mesh.topology().dim())
     mf_facets = fenics.MeshFunction("size_t", mesh, mesh.topology().dim() - 1)
-    cell_file = "cell_file.xdmf"
-    facet_file = "facet_file.xdmf"
-    fenics.XDMFFile(cell_file).write(mf_cells)
-    fenics.XDMFFile(facet_file).write(mf_facets)
+    file1 = tmpdir.join("cell_file.xdmf")
+    file2 = tmpdir.join("facet_file.xdmf")
+    fenics.XDMFFile(str(Path(file1))).write(mf_cells)
+    fenics.XDMFFile(str(Path(file2))).write(mf_facets)
     # read files
     mf_cells_2, mf_facets_2 = meshing.read_subdomains_from_xdmf(
-        mesh, cell_file, facet_file)
+        mesh, str(Path(file1)), str(Path(file2)))
 
     # check
     for cell in fenics.cells(mesh):

--- a/Tests/test_meshing.py
+++ b/Tests/test_meshing.py
@@ -158,3 +158,23 @@ def test_create_mesh_xdmf():
                 [v.point().x(), v.point().y()])
     for i in range(0, len(vertices_mesh)):
         assert vertices_mesh[i] == vertices_mesh2[i]
+
+
+def test_subdomains_from_xdmf():
+
+    # write files
+    mesh = fenics.UnitCubeMesh(6, 6, 6)
+    mf_cells = fenics.MeshFunction("size_t", mesh, mesh.topology().dim())
+    mf_facets = fenics.MeshFunction("size_t", mesh, mesh.topology().dim() - 1)
+    cell_file = "cell_file.xdmf"
+    facet_file = "facet_file.xdmf"
+    fenics.XDMFFile(cell_file).write(mf_cells)
+    fenics.XDMFFile(facet_file).write(mf_facets)
+    # read files
+    mf_cells_2, mf_facets_2 = meshing.read_subdomains_from_xdmf(
+        mesh, cell_file, facet_file)
+
+    # check
+    for cell in fenics.cells(mesh):
+        assert mf_cells[cell] == mf_cells_2[cell]
+        assert mf_facets[cell] == mf_facets_2[cell]

--- a/Tests/test_meshing.py
+++ b/Tests/test_meshing.py
@@ -92,3 +92,33 @@ def test_fail_subdomains_1D_difference_size_borders():
             ]
     with pytest.raises(ValueError, match=r'match'):
         meshing.subdomains_1D(mesh, materials, 1)
+
+
+def test_create_mesh_xdmf():
+
+    # write xdmf file
+    mesh = fenics.UnitSquareMesh(10, 10)
+    f = fenics.XDMFFile("mesh.xdmf")
+    f.write(mesh)
+
+    # read mesh
+    mesh_parameters = {
+        "cells_file": "mesh.xdmf",
+        "facets_file": "Maillages Monoblock/Mesh 8/mesh_8_line.xdmf"
+        }
+    mesh2 = meshing.create_mesh(mesh_parameters)
+
+    # check that vertices are the same
+    vertices_mesh = []
+    for f in fenics.facets(mesh):
+        for v in fenics.vertices(f):
+            vertices_mesh.append(
+                [v.point().x(), v.point().y()])
+
+    vertices_mesh2 = []
+    for f in fenics.facets(mesh2):
+        for v in fenics.vertices(f):
+            vertices_mesh2.append(
+                [v.point().x(), v.point().y()])
+    for i in range(0, len(vertices_mesh)):
+        assert vertices_mesh[i] == vertices_mesh2[i]

--- a/Tests/test_meshing.py
+++ b/Tests/test_meshing.py
@@ -73,25 +73,61 @@ def test_subdomains_1D():
             assert volume_markers[cell] == 2
 
 
-def test_fail_subdomains_1D_difference_size_borders():
-    '''
-    Test that an error is raised if the borders don't match
-    the size of the mesh
-    '''
-    mesh = fenics.UnitIntervalMesh(20)
-
+def test_check_borders():
     materials = [
         {
-            "borders": [0, 0.5],
+            "borders": [0.5, 0.7],
             "id": 1,
             },
         {
-            "borders": [0.5, 0.7],
+            "borders": [0, 0.5],
             "id": 2,
             }
             ]
-    with pytest.raises(ValueError, match=r'match'):
-        meshing.subdomains_1D(mesh, materials, 1)
+    size = 0.7
+    assert meshing.check_borders(size, materials) is True
+
+    with pytest.raises(ValueError, match=r'zero'):
+        size = 0.7
+        materials = [
+            {
+                "borders": [0.5, 0.7],
+                "id": 1,
+                },
+            {
+                "borders": [0.2, 0.5],
+                "id": 2,
+                }
+                ]
+        meshing.check_borders(size, materials)
+
+    with pytest.raises(ValueError, match=r'each other'):
+        materials = [
+            {
+                "borders": [0.5, 1],
+                "id": 1,
+                },
+            {
+                "borders": [0, 0.6],
+                "id": 2,
+                },
+            {
+                "borders": [0.6, 1],
+                "id": 3,
+                }
+                ]
+        size = 1
+        meshing.check_borders(size, materials)
+
+    with pytest.raises(ValueError, match=r'size'):
+        materials = [
+            {
+                "borders": [0, 1],
+                "id": 1,
+                }
+                ]
+        size = 3
+        meshing.check_borders(size, materials)
 
 
 def test_create_mesh_xdmf():

--- a/Tests/test_meshing.py
+++ b/Tests/test_meshing.py
@@ -179,3 +179,56 @@ def test_subdomains_from_xdmf(tmpdir):
     for cell in fenics.cells(mesh):
         assert mf_cells[cell] == mf_cells_2[cell]
         assert mf_facets[cell] == mf_facets_2[cell]
+
+
+def test_create_mesh_inbuilt():
+    '''
+    Test when mesh is given by the user
+    '''
+    # create mesh
+    mesh = fenics.UnitSquareMesh(10, 10)
+
+    # read mesh
+    mesh_parameters = {
+        "mesh": mesh
+        }
+    mesh2 = meshing.create_mesh(mesh_parameters)
+
+    # check that vertices are the same
+    vertices_mesh = []
+    for f in fenics.facets(mesh):
+        for v in fenics.vertices(f):
+            vertices_mesh.append(
+                [v.point().x(), v.point().y()])
+
+    vertices_mesh2 = []
+    for f in fenics.facets(mesh2):
+        for v in fenics.vertices(f):
+            vertices_mesh2.append(
+                [v.point().x(), v.point().y()])
+    for i in range(0, len(vertices_mesh)):
+        assert vertices_mesh[i] == vertices_mesh2[i]
+
+
+def test_subdomains_inbuilt():
+    '''
+    Test when meshfunctions are given by
+    the user
+    '''
+    # create
+    mesh = fenics.UnitCubeMesh(6, 6, 6)
+    mf_cells = fenics.MeshFunction("size_t", mesh, mesh.topology().dim())
+    mf_facets = fenics.MeshFunction("size_t", mesh, mesh.topology().dim() - 1)
+    mesh_parameters = {
+        "mesh_parameters": {
+            "mesh": mesh,
+            "meshfunction_cells": mf_cells,
+            "meshfunction_facets": mf_facets
+        }
+    }
+    # read
+    mf_cells_2, mf_facets_2 = meshing.subdomains(mesh, mesh_parameters)
+    # check
+    for cell in fenics.cells(mesh):
+        assert mf_cells[cell] == mf_cells_2[cell]
+        assert mf_facets[cell] == mf_facets_2[cell]

--- a/Tests/test_meshing.py
+++ b/Tests/test_meshing.py
@@ -141,7 +141,7 @@ def test_create_mesh_xdmf(tmpdir):
 
     # read mesh
     mesh_parameters = {
-        "cells_file": str(Path(file1)),
+        "mesh_file": str(Path(file1)),
         }
     mesh2 = meshing.create_mesh(mesh_parameters)
 


### PR DESCRIPTION
Users can now define meshes and subdomains as FEniCS objects or from XDMF files.
```python
from FESTIM import meshing
import fenics

# inbuilt FEniCS meshes and subdomains

mesh = fenics.UnitCubeMesh(6, 6, 6)
mf_cells = fenics.MeshFunction("size_t", mesh, mesh.topology().dim())
mf_facets = fenics.MeshFunction("size_t", mesh, mesh.topology().dim() - 1)
parameters = {
    "mesh_parameters": {
        "mesh": mesh,
        "meshfunction_cells": mf_cells,
        "meshfunction_facets": mf_facets
    }
}

mesh_FESTIM = meshing.create_mesh(parameters["mesh_parameters"])
subdomains_FESTIM = meshing.subdomains(mesh_FESTIM, parameters)

# from XDMF files

mesh = fenics.UnitCubeMesh(6, 6, 6)
f = fenics.XDMFFile("mesh.xdmf")
f.write(mesh)

mf_cells = fenics.MeshFunction("size_t", mesh, mesh.topology().dim())
mf_facets = fenics.MeshFunction("size_t", mesh, mesh.topology().dim() - 1)
fenics.XDMFFile("cell_file.xdmf").write(mf_cells)
fenics.XDMFFile("facet_file.xdmf").write(mf_facets)

parameters = {
    "mesh_parameters": {
        "mesh_file": "mesh.xdmf",
        "cells_file": "cell_file.xdmf",
        "facets_file": "facet_file.xdmf",
    }
}
mesh_FESTIM = meshing.create_mesh(parameters["mesh_parameters"])
subdomains_FESTIM = meshing.subdomains(mesh_FESTIM, parameters)
```
Note: When XDMF files are used, the attribute's name must be `"f"`